### PR TITLE
Update gallery & thumbnail size only when offset is not zero 

### DIFF
--- a/build/image-gallery.js
+++ b/build/image-gallery.js
@@ -147,12 +147,14 @@ var ImageGallery = function (_React$Component) {
     _this._handleResize = function () {
       var currentIndex = _this.state.currentIndex;
 
-      if (_this._imageGallery) {
-        var previousGalleryWidth = _this.state.galleryWidth;
+
+      var previousGalleryWidth = _this.state.galleryWidth;
+      if (_this._imageGallery && _this._imageGallery.offsetWidth > 0) {
         _this.setState({
           galleryWidth: _this._imageGallery.offsetWidth
         });
-        if (_this.props.onReadyToDisplay && _this._imageGallery.offsetWidth > 0 && previousGalleryWidth === 0) {
+
+        if (_this.props.onReadyToDisplay && previousGalleryWidth === 0) {
           _this.props.onReadyToDisplay();
         }
       }
@@ -163,16 +165,15 @@ var ImageGallery = function (_React$Component) {
         });
       }
 
-      if (_this._thumbnailsWrapper) {
+      if (_this._thumbnailsWrapper && _this._thumbnailsWrapper.offsetHeight != 0 && _this._thumbnailsWrapper.offsetWidth != 0) {
         if (_this._isThumbnailHorizontal()) {
           _this.setState({ thumbnailsWrapperHeight: _this._thumbnailsWrapper.offsetHeight });
         } else {
           _this.setState({ thumbnailsWrapperWidth: _this._thumbnailsWrapper.offsetWidth });
         }
+        // Adjust thumbnail container when thumbnail width or height is adjusted
+        _this._setThumbsTranslate(-_this._getThumbsTranslate(currentIndex));
       }
-
-      // Adjust thumbnail container when thumbnail width or height is adjusted
-      _this._setThumbsTranslate(-_this._getThumbsTranslate(currentIndex));
     };
 
     _this._handleKeyDown = function (event) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image-gallery",
-  "version": "0.8.14-rc1-sl",
+  "version": "0.8.15-sl",
   "description": "React carousel image gallery component with thumbnail and mobile support",
   "main": "./build/image-gallery.js",
   "scripts": {

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -423,12 +423,14 @@ export default class ImageGallery extends React.Component {
 
   _handleResize = () => {
     const { currentIndex } = this.state;
-    if (this._imageGallery) {
-      const previousGalleryWidth = this.state.galleryWidth;
+
+    const previousGalleryWidth = this.state.galleryWidth;
+    if (this._imageGallery && this._imageGallery.offsetWidth > 0) {
       this.setState({
-        galleryWidth: this._imageGallery.offsetWidth
-      });
-      if (this.props.onReadyToDisplay && this._imageGallery.offsetWidth > 0 && previousGalleryWidth === 0) {
+              galleryWidth: this._imageGallery.offsetWidth
+          });
+
+      if (this.props.onReadyToDisplay && previousGalleryWidth === 0) {
         this.props.onReadyToDisplay();
       }
     }
@@ -439,16 +441,15 @@ export default class ImageGallery extends React.Component {
       });
     }
 
-    if (this._thumbnailsWrapper) {
+    if (this._thumbnailsWrapper && this._thumbnailsWrapper.offsetHeight != 0 && this._thumbnailsWrapper.offsetWidth != 0) {
       if (this._isThumbnailHorizontal()) {
-        this.setState({thumbnailsWrapperHeight: this._thumbnailsWrapper.offsetHeight});
+          this.setState({thumbnailsWrapperHeight: this._thumbnailsWrapper.offsetHeight});
       } else {
-        this.setState({thumbnailsWrapperWidth: this._thumbnailsWrapper.offsetWidth});
+            this.setState({thumbnailsWrapperWidth: this._thumbnailsWrapper.offsetWidth});
       }
+      // Adjust thumbnail container when thumbnail width or height is adjusted
+      this._setThumbsTranslate(-this._getThumbsTranslate(currentIndex));
     }
-
-    // Adjust thumbnail container when thumbnail width or height is adjusted
-    this._setThumbsTranslate(-this._getThumbsTranslate(currentIndex));
   };
 
   _isThumbnailHorizontal() {


### PR DESCRIPTION
Added a condition that on resize checks that the value of `_imageGallery.offsetWidth` is not zero, and only if this is true it updates the state of the `galleryWidth.`  
The same with the `offsetHeight` and `offsetWidth` of the `_thumbnailsWrapper`. (And only when these states change, the thumbnail container adjustment is performed).

This is needed in order that 'translations to zero' do not occur.
In other words the photos/videos should not be affected by a resize which would lead to a
translation to zero/initial state when a Tab change (grandparent component) occurs, for example.
The lack of these conditions produce a translation to the first photo (zero) when changing from
photo/video tab and when changing back to it a fast slide from the first to the current photo/video
happens (which is not desirable).