### PR TITLE
Fix crash occurring when the gallery is empty

### DIFF
--- a/build/image-gallery.js
+++ b/build/image-gallery.js
@@ -384,7 +384,10 @@ var ImageGallery = function (_React$Component) {
     value: function componentDidUpdate(prevProps, prevState) {
       var itemsChanged = prevProps.items.length !== this.props.items.length;
       if (itemsChanged) {
-        var coverPhotoChange = prevProps.items[prevProps.startIndex].id !== this.props.items[this.props.startIndex].id;
+        var prevCoverPhoto = prevProps.items[prevProps.startIndex] || {};
+        var newCoverPhoto = this.props.items[this.props.startIndex] || {};
+        var coverPhotoChanged = prevCoverPhoto.id !== newCoverPhoto.id;
+
         if (coverPhotoChange && this.props.onItemsGalleryChange) {
           // call the callback function
           this.props.onItemsGalleryChange();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-image-gallery",
-  "version": "0.8.21-sl",
+  "version": "0.8.22-sl",
   "description": "React carousel image gallery component with thumbnail and mobile support",
   "main": "./build/image-gallery.js",
   "scripts": {

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -181,7 +181,10 @@ export default class ImageGallery extends React.Component {
   componentDidUpdate(prevProps, prevState) {
     const itemsChanged = prevProps.items.length !== this.props.items.length;
     if (itemsChanged) {
-      const coverPhotoChange = prevProps.items[prevProps.startIndex].id !== this.props.items[this.props.startIndex].id;
+        const prevCoverPhoto = prevProps.items[prevProps.startIndex] || {};
+        const newCoverPhoto = this.props.items[this.props.startIndex] || {};
+        const coverPhotoChanged = prevCoverPhoto.id !== newCoverPhoto.id;
+
         if (coverPhotoChange && this.props.onItemsGalleryChange) {
             // call the callback function
             this.props.onItemsGalleryChange();


### PR DESCRIPTION
Sentry error:

undefined is not an object (evaluating 'this.props.items[this.props.startIndex].id')